### PR TITLE
Fix typing and run it in CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,6 +27,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox poetry
-    - name: Test with pytest
+    - name: Test and run checks
       run: |
         tox -e py,lint,typing

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,4 +29,4 @@ jobs:
         pip install tox poetry
     - name: Test with pytest
       run: |
-        tox -e py,lint
+        tox -e py,lint,typing

--- a/tox.ini
+++ b/tox.ini
@@ -14,5 +14,7 @@ skip_install = True
 
 
 [testenv:typing]
-deps = mypy
+deps =
+    types-toml
+    mypy
 commands = mypy philter_lite/


### PR DESCRIPTION
We need the toml stubs package for typing to work.

Also typing wasn't runnin in CI so we should do that. Note that the reason we pass the `-e` parameter and don't just do `tox` is because we only want it to run for the currently set up python version.