### PR TITLE
Stop installing poetry in CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox poetry
+        pip install tox
     - name: Test and run checks
       run: |
         tox -e py,lint,typing


### PR DESCRIPTION
tox will install poetry_core through the build-system directive. Installing the full poetry is unnecessary.