### PR TITLE
Improve performance a bit

### DIFF
--- a/philter_lite/filters/__init__.py
+++ b/philter_lite/filters/__init__.py
@@ -2,7 +2,7 @@ import os
 import re
 import warnings
 from dataclasses import dataclass
-from typing import List, Optional, Pattern
+from typing import List, Optional, Pattern, Set
 
 import toml
 
@@ -19,8 +19,8 @@ class Filter:
 
 @dataclass(frozen=True)
 class SetFilter(Filter):
-    pos: List[str]
-    data: List[str]
+    pos: Set[str]
+    data: Set[str]
 
 
 @dataclass(frozen=True)
@@ -81,8 +81,8 @@ def filter_from_dict(
             title=filter_dict["title"],
             type=filter_type,
             exclude=filter_dict["exclude"],
-            data=data,
-            pos=filter_dict["pos"],
+            data=set(data),
+            pos=set(filter_dict["pos"]),
             phi_type=filter_dict.get("phi_type", "OTHER"),
         )
     elif filter_type == "regex":

--- a/tests/test_philter.py
+++ b/tests/test_philter.py
@@ -61,7 +61,7 @@ def test_filter_from_dict():
     assert filter.title == "Whitelist 1"
     assert filter.data is not None
     assert filter.exclude is False
-    assert filter.pos == []
+    assert filter.pos == set()
     assert isinstance(filter, filters.SetFilter)
 
     filter_dict = {


### PR DESCRIPTION
### Description
These are some low-hanging-fruit fixes, which in my brief testing reduces execution times by 70%.

- Use pre-compiled regexes where possible (this may not be a huge win, because the docs suggest they cache recently used ones, but still)
- Use an actual set() data type for SetFilter, to avoid iterating a big list for every word
- Calculate the part-of-speech list once rather than per-filter

### Testing

Run the following before/after:
```
python3 -m timeit -u msec -n 300 -s 'import os, philter_lite; filters=philter_lite.load_filters(f"{os.path.dirname(philter_lite.__file__)}/configs/philter_delta.toml")' "philter_lite.detect_phi(\"what's up doc\", filters)"
```

On my laptop, I get (repeat attempts bounce around these numbers):
- Before: `300 loops, best of 5: 2.72 msec per loop`
- After: `300 loops, best of 5: 0.721 msec per loop`

That's a 73% improvement!

### Next steps

I was using philter for many small pieces of text and it felt quite slow to me. So I started seeing if there was any easy wins there, and thankfully I found a few!

I bet there could be other wins, like maybe unifying multiple RegexFilters into one big regex? But that felt like maybe a distinct PR / effort. Here are some snakeviz charts from before and after, if it triggers anyone's thoughts for more wins:

#### Before

![Screenshot from 2023-03-07 16-19-18](https://user-images.githubusercontent.com/1196901/223555389-4d7e721c-c295-4d57-832c-1f62e6522d62.png)

#### After 
![Screenshot from 2023-03-07 16-22-39](https://user-images.githubusercontent.com/1196901/223555908-ffbd0652-f5c0-459f-9c0c-56ed9e643112.png)
