### PR TITLE
Bogus PR: releasing to pypi is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- Don't land this change -->
+
 # UCSF Philter Lite
 ![Python Package](https://github.com/TimOrme/philter-ucsf/workflows/Python%20package/badge.svg)
 [![PyPI version](https://badge.fury.io/py/philter-lite.svg)](https://pypi.org/project/philter-lite/)


### PR DESCRIPTION
Hello! This repo does not have GitHub issues enabled, so I couldn't file a ticket about this. Hence this bogus PR, which you should not land.

Actual issue: I noticed that the 0.4.0 release never made it into pypi. You can see the [Actions event that tried](https://github.com/SironaMedical/philter-lite/actions/runs/6021064078), but failed to push it. Here is the error:

```
Run poetry config pypi-token.pypi ${PYPI_TOKEN}
  poetry config pypi-token.pypi ${PYPI_TOKEN}
  poetry publish --build
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.11.4/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.4/x64/lib
    PYPI_TOKEN: 

There is no pypi-token.pypi setting.
Error: Process completed with exit code 1.
```