### PR TITLE
AIE-3321 fix importlib resources deprecation warnings

### DIFF
--- a/philter_lite/__init__.py
+++ b/philter_lite/__init__.py
@@ -1,4 +1,5 @@
 """The philter_lite package."""
+
 from importlib import metadata
 
 from philter_lite.coordinate_map import CoordinateMap

--- a/philter_lite/filters/filter_db.py
+++ b/philter_lite/filters/filter_db.py
@@ -1,5 +1,5 @@
 import sys
-from importlib import resources
+from importlib.resources import as_file, files
 from typing import Any, MutableMapping
 
 if sys.version_info < (3, 11):
@@ -7,20 +7,27 @@ if sys.version_info < (3, 11):
 else:
     import tomllib
 
-
 from philter_lite import filters
 
 
+def _get_toml_from_filters(filename: str) -> MutableMapping[str, Any]:
+    source = files(filters).joinpath(filename)
+    with as_file(source) as path:
+        with open(path, "rb") as toml_file:
+            toml_data = tomllib.load(toml_file)
+    return toml_data
+
+
 def load_regex_db() -> MutableMapping[str, Any]:
-    return tomllib.loads(resources.read_text(filters, "regex.toml"))
+    return _get_toml_from_filters("regex.toml")
 
 
 def load_regex_context_db() -> MutableMapping[str, Any]:
-    return tomllib.loads(resources.read_text(filters, "regex_context.toml"))
+    return _get_toml_from_filters("regex_context.toml")
 
 
 def load_set_db() -> MutableMapping[str, Any]:
-    return tomllib.loads(resources.read_text(filters, "set.toml"))
+    return _get_toml_from_filters("set.toml")
 
 
 regex_db: MutableMapping[str, Any] = load_regex_db()

--- a/poetry.lock
+++ b/poetry.lock
@@ -503,4 +503,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "aca5dcaa2846ab83962002d990bad5967b86ac557b079270c228108710be7372"
+content-hash = "fb0e296d80c3fae8f40fa29ae4c949bab9a2afc3a6645d9089952644706dc72a"


### PR DESCRIPTION
## Resolving importlib.resources warnings

Tests and usage of philters_lite generates warnings due to usage of deprecated interfaces from importlib.resources.  To wit:
```
philter_lite/filters/filter_db.py:15
  /Users/jclerman/git/philter-lite/philter_lite/filters/filter_db.py:15: DeprecationWarning: read_text is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    return tomllib.loads(resources.read_text(filters, "regex.toml"))

../../.pyenv/versions/3.11.10/lib/python3.11/importlib/resources/_legacy.py:80
minor linting fix
../../.pyenv/versions/3.11.10/lib/python3.11/importlib/resources/_legacy.py:80
../../.pyenv/versions/3.11.10/lib/python3.11/importlib/resources/_legacy.py:80
  /Users/jclerman/.pyenv/versions/3.11.10/lib/python3.11/importlib/resources/_legacy.py:80: DeprecationWarning: open_text is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    with open_text(package, resource, encoding, errors) as fp:

philter_lite/filters/filter_db.py:19
  /Users/jclerman/git/philter-lite/philter_lite/filters/filter_db.py:19: DeprecationWarning: read_text is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    return tomllib.loads(resources.read_text(filters, "regex_context.toml"))

philter_lite/filters/filter_db.py:23
  /Users/jclerman/git/philter-lite/philter_lite/filters/filter_db.py:23: DeprecationWarning: read_text is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    return tomllib.loads(resources.read_text(filters, "set.toml"))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

Here, switching to usage of the new interface to resolve those warnings (and avoid use of a deprecated interface).